### PR TITLE
Use threshold signature as source of randomness

### DIFF
--- a/commoncoin/boldyreva.py
+++ b/commoncoin/boldyreva.py
@@ -83,6 +83,7 @@ class TBLSPublicKey(object):
 
     def verify_signature(self, sig, h):
         assert pair(sig, g2) == pair(h, self.VK)
+        return True
 
     def combine_shares(self, sigs):
         # sigs: a mapping from idx -> sig

--- a/commoncoin/boldyreva_gipc.py
+++ b/commoncoin/boldyreva_gipc.py
@@ -20,7 +20,7 @@ def _worker(PK,pipe):
         h = deserialize1(h)
         sig = PK.combine_shares(sigs)
         res = PK.verify_signature(sig, h)
-        pipe.put(res)
+        pipe.put((res,serialize(sig)))
 
 myPK = None
 
@@ -41,7 +41,9 @@ def combine_and_verify(h, sigs):
     # Pick a random process
     _,pipe = _procs[random.choice(range(len(_procs)))] #random.choice(_procs)
     pipe.put((h,sigs))
-    assert pipe.get() == True
+    (r,s) = pipe.get() 
+    assert r == True
+    return s
 
 def pool_test():
     global PK, SKs

--- a/core/broadcasts.py
+++ b/core/broadcasts.py
@@ -101,8 +101,9 @@ def shared_coin(instance, pid, N, t, broadcast, receive):
             if len(received[r]) == t + 1:
                     h = PK.hash_message(str((r, instance)))
                     def tmpFunc(r, t):
-                        combine_and_verify(h, dict(tuple((t, deserialize1(sig)) for t, sig in received[r])[:t+1]))
-                        outputQueue[r].put(ord(serialize(h)[0]) & 1)  # explicitly convert to int
+                        # Verify and get the combined signature
+                        s = combine_and_verify(h, dict(tuple((t, deserialize1(sig)) for t, sig in received[r])[:t+1]))
+                        outputQueue[r].put(ord(s[0]) & 1)  # explicitly convert to int
                     Greenlet(
                         tmpFunc, r, t
                     ).start()


### PR DESCRIPTION
`combine_and_verify` in `boldyreva_gipc` now returns combined signature.
I hope this commit(ac787c4) fixes #2 .
Tried `boldyreva_gipc.pool_test()` and `HoneyBadgerBFT.test.honest_party_test`, seems nothing broken.


