### PR TITLE
Add travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: python
+python: 2.7
+
+env:
+  global:
+  - LIBRARY_PATH=/usr/local/lib
+  - LD_LIBRARY_PATH=/usr/local/lib
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get -y install flex bison libgmp-dev libmpc-dev python-dev libssl-dev
+  - wget https://crypto.stanford.edu/pbc/files/pbc-0.5.14.tar.gz
+  - tar -xvf pbc-0.5.14.tar.gz
+  - cd pbc-0.5.14 
+  - ./configure
+  - make
+  - sudo make install
+  - cd .. && git clone https://github.com/JHUISI/charm.git
+  - cd charm && git checkout 2.7-dev
+  - ./configure.sh
+  - python setup.py install
+  - cd ..
+
+install:
+  - pip install --upgrade pip codecov
+  - pip install -e .[test]
+
+script: pytest -v test/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ The Honey Badger of BFT Protocols
 
 <img width=200 src="http://i.imgur.com/wqzdYl4.png"/>
 
+[![Travis branch](https://img.shields.io/travis/amiller/HoneyBadgerBFT/travis-ci.svg)](https://travis-ci.org/amiller/HoneyBadgerBFT)
+
 Most fault tolerant protocols (including RAFT, PBFT, Zyzzyva, Q/U) don't guarantee good performance when there are Byzantine faults.
 Even the so-called "robust" BFT protocols (like UpRight, RBFT, Prime, Spinning, and Stellar) have various hard-coded timeout parameters, and can only guarantee performance when the network behaves approximately as expected - hence they are best suited to well-controlled settings like corporate data centers.
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Most fault tolerant protocols (including RAFT, PBFT, Zyzzyva, Q/U)
+don't guarantee good performance when there are Byzantine faults. Even
+the so-called "robust" BFT protocols (like UpRight, RBFT, Prime,
+Spinning, and Stellar) have various hard-coded timeout parameters, and
+can only guarantee performance when the network behaves approximately as
+expected - hence they are best suited to well-controlled settings like
+corporate data centers.
+
+HoneyBadgerBFT is fault tolerance for the wild wild wide-area-network.
+HoneyBadger nodes can even stay hidden behind anonymizing relays like
+Tor, and the purely-asynchronous protocol will make progress at whatever
+rate the network supports.
+
+"""
+from setuptools import setup
+
+
+install_requires = [
+    'gevent',
+    'gmpy2',
+    'pysocks',
+    'pycrypto',
+    'ecdsa',
+    'zfec',
+    'gipc',
+]
+
+tests_require = [
+    'coverage',
+    'flake8',
+    'pytest',
+    'pytest-cov',
+    'pytest-sugar',
+    'nose2',
+]
+
+dev_require = [
+    'ipdb',
+    'ipython~=5.3',
+]
+
+docs_require = [
+    # jinja2 is pinned because of issue with async syntax, e.g., see:
+    #  - https://github.com/pallets/jinja/issues/643,
+    #  - https://github.com/pallets/jinja/issues/653
+    'jinja2==2.8',
+    'Sphinx',
+    'sphinx-autobuild',
+    'sphinx_rtd_theme',
+]
+
+setup(
+    name='honeybadgerbft',
+    version='0.1.0',
+    description='The Honey Badger of BFT Protocols',
+    long_description=__doc__,
+    author="Andrew Miller et al.",
+    url='https://github.com/amiller/HoneyBadgerBFT',
+    packages=['honeybadgerbft'],
+    package_dir={'honeybadgerbft': 'honeybadgerbft'},
+    include_package_data=True,
+    install_requires=install_requires,
+    license='CRAPL',
+    zip_safe=False,
+    keywords='distributed systems, cryptography, byzantine fault tolerance',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 2 :: Only',
+        'Programming Language :: Python :: 2.7',
+    ],
+    test_suite='tests',
+    extras_require={
+        'test': tests_require,
+        'dev': dev_require + tests_require + docs_require,
+        'docs': docs_require,
+    },
+)


### PR DESCRIPTION
closes #24 

### Notes
**(1)** The PR has been made against the `dev` branch.
**(2)** The commit (775fde5bde1fc6f880e3b1a464564eea6a55b862) that adds the `setup.py` is both in this PR and PR #21, so we can either merge PR #21 first and then rebase this one or simply merge this one and close #21.
**(3)** The codecov integration will be made in a different PR to avoid the problem explained in https://github.com/codecov/support/issues/363 and https://docs.codecov.io/docs/error-reference#section-missing-base-commit
**(4)** You may notice that `pytest` is used instead of `nose2`. I would recommend using `pytest` but if you prefer to stick to `nose2` it's fine. We can discuss the testing framework in a separate issue if you wish.