### PR TITLE
Codecov integration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,17 @@
+codecov:
+  branch: dev
+
+coverage:
+  range: 70..100
+  round: down
+  precision: 5
+
+  ignore:
+    - "docs/*"
+    - "experiments/*"
+    - "misc/*"
+    - "test/*"
+
+comment:
+  layout: "header, diff, changes, sunburst, uncovered"
+  behavior: default

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+source = .
+omit = *test*, docs/*, setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,6 @@ install:
   - pip install --upgrade pip codecov
   - pip install -e .[test]
 
-script: pytest -v test/
+script: pytest -v --cov=honeybadgerbft test/
+
+after_success: codecov

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ The Honey Badger of BFT Protocols
 <img width=200 src="http://i.imgur.com/wqzdYl4.png"/>
 
 [![Travis branch](https://img.shields.io/travis/amiller/HoneyBadgerBFT/dev.svg)](https://travis-ci.org/amiller/HoneyBadgerBFT)
+[![Codecov branch](https://img.shields.io/codecov/c/github/amiller/honeybadgerbft/dev.svg)](https://codecov.io/github/amiller/honeybadgerbft?branch=dev)
 
 Most fault tolerant protocols (including RAFT, PBFT, Zyzzyva, Q/U) don't guarantee good performance when there are Byzantine faults.
 Even the so-called "robust" BFT protocols (like UpRight, RBFT, Prime, Spinning, and Stellar) have various hard-coded timeout parameters, and can only guarantee performance when the network behaves approximately as expected - hence they are best suited to well-controlled settings like corporate data centers.


### PR DESCRIPTION
The codecov error is due to the fact that the `dev` (parent) branch does not have a report uploaded yet. I am not sure how someone is supposed to get the thing started without getting this error, since that is the whole point of this PR: to upload the first report :smile: ! Seems related to issue https://github.com/codecov/support/issues/363

I think we can ignore the codecov error and future PRs should be fine.