### PR TITLE
Fix assert N lte f*3 + 1 statement in rbc

### DIFF
--- a/honeybadgerbft/core/reliablebroadcast.py
+++ b/honeybadgerbft/core/reliablebroadcast.py
@@ -132,7 +132,7 @@ def reliablebroadcast(sid, pid, N, f, leader, input, receive, send):
     necessarily reconstructed, then evidence incriminates the leader.
 
     """
-    assert N <= 3*f + 1
+    assert N >= 3*f + 1
     assert f >= 0
     assert 0 <= leader < N
     assert 0 <= pid    < N

--- a/test/test_rbc.py
+++ b/test/test_rbc.py
@@ -3,6 +3,7 @@ import random
 import gevent
 from gevent import Greenlet
 from gevent.queue import Queue
+from pytest import mark
 
 from honeybadgerbft.core.reliablebroadcast import reliablebroadcast, encode, decode
 from honeybadgerbft.core.reliablebroadcast import hash, merkleTree, getMerkleBranch, merkleVerify
@@ -88,9 +89,11 @@ def _test_rbc1(N=4, f=1, leader=None, seed=None):
     gevent.joinall(threads)
     assert [t.value for t in threads] == [m]*N
 
-def test_rbc1():
+
+@mark.parametrize('N,f', ((4, 1), (5, 1), (8, 2)))
+def test_rbc1(N, f):
     for i in range(20):
-        _test_rbc1(seed=i)
+        _test_rbc1(N=N, f=f, seed=i)
 
 
 def _test_rbc2(N=4, f=1, leader=None, seed=None):

--- a/test/test_rbc.py
+++ b/test/test_rbc.py
@@ -89,7 +89,9 @@ def _test_rbc1(N=4, f=1, leader=None, seed=None):
     assert [t.value for t in threads] == [m]*N
 
 def test_rbc1():
-    for i in range(20): _test_rbc1(seed=i)
+    for i in range(20):
+        _test_rbc1(seed=i)
+
 
 def _test_rbc2(N=4, f=1, leader=None, seed=None):
     # Crash up to f nodes

--- a/test/test_rbc.py
+++ b/test/test_rbc.py
@@ -1,4 +1,3 @@
-import unittest
 from gevent import Greenlet
 from gevent.queue import Queue
 import gevent

--- a/test/test_rbc.py
+++ b/test/test_rbc.py
@@ -1,9 +1,12 @@
+import random
+
+import gevent
 from gevent import Greenlet
 from gevent.queue import Queue
-import gevent
-import random
+
 from honeybadgerbft.core.reliablebroadcast import reliablebroadcast, encode, decode
 from honeybadgerbft.core.reliablebroadcast import hash, merkleTree, getMerkleBranch, merkleVerify
+
 
 ### Merkle tree
 def test_merkletree0():


### PR DESCRIPTION
See failed test for `(N=5, f=1)` at https://travis-ci.org/amiller/HoneyBadgerBFT/builds/268545803#L1923

### Note about usage of `pytest`
I decided to use `pytest` to showcase some of its powers. That is barely scratching the surface, but yet the parametrization capabilities of `pytest` are very useful and can save considerable development time.

I suspect that something similar can be achieved with `nose2` but I didn't have enough time to look into it.

When I have time I can write the test with `nose2` parametrization approach.