### PR TITLE
Docs libref

### DIFF
--- a/.ci/travis-after-success.sh
+++ b/.ci/travis-after-success.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ "${BUILD}" == "tests" ]; then
+    codecov
+fi

--- a/.ci/travis-before-install.sh
+++ b/.ci/travis-before-install.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ "${BUILD}" != "flake8" ]; then
+    apt-get update -qq
+    apt-get -y install flex bison libgmp-dev libmpc-dev python-dev libssl-dev
+    wget https://crypto.stanford.edu/pbc/files/pbc-0.5.14.tar.gz
+    tar -xvf pbc-0.5.14.tar.gz
+    cd pbc-0.5.14 
+    ./configure
+    make
+    make install
+    cd ..
+fi

--- a/.ci/travis-install.sh
+++ b/.ci/travis-install.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+pip install --upgrade pip
+
+# will not be needed for flake8
+git clone https://github.com/JHUISI/charm.git
+cd charm && git checkout 2.7-dev
+./configure.sh
+python setup.py install
+cd ..
+
+if [ "${BUILD}" == "tests" ]; then
+    pip install -e .[test]
+    pip install --upgrade codecov
+elif [ "${BUILD}" == "docs" ]; then
+    pip install -e .[docs]
+fi

--- a/.ci/travis-script.sh
+++ b/.ci/travis-script.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ "${BUILD}" == "tests" ]; then
+    pytest -v --cov=honeybadgerbft test/
+elif [ "${BUILD}" == "docs" ]; then
+    sphinx-build -W -c docs -b html -d docs/_build/doctrees docs docs/_build/html
+fi

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,6 @@
 [run]
 source = .
 omit = *test*, docs/*, setup.py
+
+[run]
+concurrency = gevent

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ ec2/logs_old/*
 ec2/hosts
 *_keys
 *.keys
+
+# Sphinx documentation
+docs/_build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,25 +6,12 @@ env:
   - LIBRARY_PATH=/usr/local/lib
   - LD_LIBRARY_PATH=/usr/local/lib
 
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get -y install flex bison libgmp-dev libmpc-dev python-dev libssl-dev
-  - wget https://crypto.stanford.edu/pbc/files/pbc-0.5.14.tar.gz
-  - tar -xvf pbc-0.5.14.tar.gz
-  - cd pbc-0.5.14 
-  - ./configure
-  - make
-  - sudo make install
-  - cd .. && git clone https://github.com/JHUISI/charm.git
-  - cd charm && git checkout 2.7-dev
-  - ./configure.sh
-  - python setup.py install
-  - cd ..
+matrix:
+  include:
+    - env: BUILD=tests
+    - env: BUILD=docs
 
-install:
-  - pip install --upgrade pip codecov
-  - pip install -e .[test]
-
-script: pytest -v --cov=honeybadgerbft test/
-
-after_success: codecov
+before_install: sudo .ci/travis-before-install.sh
+install:  .ci/travis-install.sh
+script: .ci/travis-script.sh
+after_success: .ci/travis-after-success.sh

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line.
+SPHINXOPTS    =
+SPHINXBUILD   = python -msphinx
+SPHINXPROJ    = HoneyBadgerBFT
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+
+import sphinx_rtd_theme
+
+
+# -- General configuration ------------------------------------------------
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.todo',
+    'sphinx.ext.coverage',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.viewcode',
+]
+
+autodoc_default_flags = [
+    'members',
+    'private-members',
+    'inherited-members',
+    'show-inheritance',
+]
+autoclass_content = 'both'
+
+templates_path = ['_templates']
+source_suffix = '.rst'
+master_doc = 'index'
+project = u'HoneyBadgerBFT'
+copyright = u'2017, Andrew Miller et al.'
+author = u'Andrew Miller et al.'
+version = u'0.1'
+release = u'0.1.0'
+language = None
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+pygments_style = 'sphinx'
+todo_include_todos = True
+
+
+# -- Options for HTML output ----------------------------------------------
+
+html_theme = 'sphinx_rtd_theme'
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_sidebars = {
+    '**': [
+        'about.html',
+        'navigation.html',
+        'relations.html',  # needs 'show_related': True theme option to display
+        'searchbox.html',
+        'donate.html',
+    ]
+}
+
+
+# -- Options for HTMLHelp output ------------------------------------------
+
+htmlhelp_basename = 'HoneyBadgerBFTdoc'
+
+
+# -- Options for LaTeX output ---------------------------------------------
+
+latex_elements = {}
+latex_documents = [
+    (master_doc, 'HoneyBadgerBFT.tex', u'HoneyBadgerBFT Documentation',
+     u'Andrew Miller et al.', 'manual'),
+]
+
+
+# -- Options for manual page output ---------------------------------------
+
+man_pages = [
+    (master_doc, 'honeybadgerbft', u'HoneyBadgerBFT Documentation',
+     [author], 1)
+]
+
+
+# -- Options for Texinfo output -------------------------------------------
+
+texinfo_documents = [
+    (master_doc, 'HoneyBadgerBFT', u'HoneyBadgerBFT Documentation',
+     author, 'HoneyBadgerBFT', 'One line description of project.',
+     'Miscellaneous'),
+]
+
+
+intersphinx_mapping = {'https://docs.python.org/': None}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,8 @@ Welcome to HoneyBadgerBFT's documentation!
    :maxdepth: 1
    :caption: Contents:
    
+   libref
+
 
 Indices and tables
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,19 @@
+.. HoneyBadgerBFT documentation master file, created by
+   sphinx-quickstart on Wed Aug 16 12:55:00 2017.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to HoneyBadgerBFT's documentation!
+==========================================
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Contents:
+   
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/libref.rst
+++ b/docs/libref.rst
@@ -1,0 +1,98 @@
+*****************
+Library Reference
+*****************
+
+Core
+----
+.. automodule:: honeybadgerbft.core
+    :members:
+
+Binary Agreement
+^^^^^^^^^^^^^^^^
+.. automodule:: honeybadgerbft.core.binaryagreement
+    :members:
+
+Common Coin
+^^^^^^^^^^^
+.. autoexception:: honeybadgerbft.core.commoncoin.CommonCoinFailureException
+
+.. automethod:: honeybadgerbft.core.commoncoin.shared_coin
+
+Asynchronous Common Subset (ACS)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automodule:: honeybadgerbft.core.commonsubset
+    :members:
+
+HoneyBadgerBFT
+^^^^^^^^^^^^^^
+.. autoclass:: honeybadgerbft.core.honeybadger.HoneyBadgerBFT
+    :members:
+    :private-members:
+
+HoneyBadger Block
+^^^^^^^^^^^^^^^^^
+.. automodule:: honeybadgerbft.core.honeybadger_block
+    :members:
+
+Reliable Broadcast
+^^^^^^^^^^^^^^^^^^
+.. automodule:: honeybadgerbft.core.reliablebroadcast
+    :members:
+
+Crypto
+------
+.. automodule:: honeybadgerbft.crypto
+    :members:
+
+
+Elliptic Curve Digital Signature Algorithm
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automodule:: honeybadgerbft.crypto.ecdsa
+    :members:
+
+.. automodule:: honeybadgerbft.crypto.ecdsa.ecdsa_ssl
+    :members:
+
+.. automodule:: honeybadgerbft.crypto.ecdsa.generate_keys_ecdsa
+    :members:
+
+Threshold Encryption
+^^^^^^^^^^^^^^^^^^^^
+.. automodule:: honeybadgerbft.crypto.threshenc
+    :members:
+
+.. automodule:: honeybadgerbft.crypto.threshenc.generate_keys
+    :members:
+
+.. automodule:: honeybadgerbft.crypto.threshenc.tpke
+    :members:
+
+Threshold Signature
+^^^^^^^^^^^^^^^^^^^
+.. automodule:: honeybadgerbft.crypto.threshsig
+    :members:
+
+boldyreva
+"""""""""
+.. automodule:: honeybadgerbft.crypto.threshsig.boldyreva
+    :members:
+
+boldyreva_gibc
+""""""""""""""
+.. automodule:: honeybadgerbft.crypto.threshsig.boldyreva_gipc
+    :members:
+
+boldyreva_pool
+""""""""""""""
+.. automodule:: honeybadgerbft.crypto.threshsig.boldyreva_pool
+    :members:
+
+generate_keys
+"""""""""""""
+.. automodule:: honeybadgerbft.crypto.threshsig.generate_keys
+    :members:
+
+millerrabin
+"""""""""""
+.. automodule:: honeybadgerbft.crypto.threshsig.millerrabin
+    :members:

--- a/honeybadgerbft/core/binaryagreement.py
+++ b/honeybadgerbft/core/binaryagreement.py
@@ -3,18 +3,20 @@ from gevent.event import Event
 from collections import defaultdict
 
 def binaryagreement(sid, pid, N, f, coin, input, decide, broadcast, receive):
-    '''Binary consensus from [MMR14]. It takes an input vi and will finally write the decided value into _decide_ channel.
+    """Binary consensus from [MMR14]. It takes an input ``vi`` and will
+    finally write the decided value into ``decide`` channel.
+
     :param sid: session identifier
     :param pid: my id number
     :param N: the number of parties
     :param f: the number of byzantine parties
-    :param coin: a common coin(r) is called to block until receiving a bit
-    :param input: input() is called to receive an input
-    :param decide: decide(0) or output(1) is eventually called
+    :param coin: a ``common coin(r)`` is called to block until receiving a bit
+    :param input: ``input()`` is called to receive an input
+    :param decide: ``decide(0)`` or ``output(1)`` is eventually called
     :param broadcast: broadcast channel
     :param receive: receive channel
-    :return: blocks until 
-    '''
+    :return: blocks until
+    """
     # Messages received are routed to either a shared coin, the broadcast, or AUX
     est_values = defaultdict(lambda:[set(),set()])
     aux_values = defaultdict(lambda:[set(),set()])

--- a/honeybadgerbft/core/commonsubset.py
+++ b/honeybadgerbft/core/commonsubset.py
@@ -2,13 +2,18 @@ import gevent
 
 def commonsubset(pid, N, f, rbc_out, aba_in, aba_out):
     """The BKR93 algorithm for asynchronous common subset.
+
     :param pid: my identifier
     :param N: number of nodes
     :param f: fault tolerance
-    :param rbc_out: an array of N (blocking) output functions, returning a string
-    :param aba_in: an array of N (non-blocking) functions that accept an input bit
-    :param aba_out: an array of N (blocking) output functions, returning a bit
-    :return: an N-element array, each element either None or a string
+    :param rbc_out: an array of :math:`N` (blocking) output functions,
+        returning a string
+    :param aba_in: an array of :math:`N` (non-blocking) functions that
+        accept an input bit
+    :param aba_out: an array of :math:`N` (blocking) output functions,
+        returning a bit
+    :return: an :math:`N`-element array, each element either ``None`` or a
+        string
     """
     assert len(rbc_out) == N
     assert len(aba_in ) == N
@@ -28,7 +33,7 @@ def commonsubset(pid, N, f, rbc_out, aba_in, aba_out):
             aba_in[j]( 1 )
 
     r_threads = [gevent.spawn(_recv_rbc, j) for j in range(N)]
-        
+
     def _recv_aba(j):
         # Receive output from binary agreement
         aba_values[j] = aba_out[j]()  # May block

--- a/honeybadgerbft/core/honeybadger_block.py
+++ b/honeybadgerbft/core/honeybadger_block.py
@@ -25,6 +25,7 @@ def deserialize_UVW( UVW ):
 
 def honeybadger_block(pid, N, f, PK, SK, propose_in, acs_in, acs_out, tpke_bcast, tpke_recv):
     """The HoneyBadgerBFT algorithm for a single block
+
     :param pid: my identifier
     :param N: number of nodes
     :param f: fault tolerance
@@ -33,14 +34,14 @@ def honeybadger_block(pid, N, f, PK, SK, propose_in, acs_in, acs_out, tpke_bcast
     :param propose_in: a function returning a sequence of transactions
     :param acs_in: a function to provide input to acs routine
     :param acs_out: a blocking function that returns an array of ciphertexts
-    :param tpke_send:
-    :param tpke_recv: 
-    :return: 
+    :param tpke_bcast:
+    :param tpke_recv:
+    :return:
     """
 
     # Broadcast inputs are of the form (tenc(key), enc(key, transactions))
-    
-    # Threshold encrypt 
+
+    # Threshold encrypt
     # TODO: check that propose_in is the correct length, not too large
     prop = propose_in()
     key = os.urandom(32) # random 256-bit key

--- a/honeybadgerbft/crypto/ecdsa/__init__.py
+++ b/honeybadgerbft/crypto/ecdsa/__init__.py
@@ -1,1 +1,3 @@
+"""ecdsa modules"""
+
 __author__ = 'aluex'

--- a/honeybadgerbft/crypto/ecdsa/ecdsa_ssl.py
+++ b/honeybadgerbft/crypto/ecdsa/ecdsa_ssl.py
@@ -13,6 +13,7 @@ NID_secp256k1 = 714 # from openssl/obj_mac.h
 
 # Thx to Sam Devlin for the ctypes magic 64-bit fix.
 def check_result (val, func, args):
+    """ """
     if val == 0:
         raise ValueError
     else:
@@ -22,18 +23,22 @@ ssl.EC_KEY_new_by_curve_name.restype = ctypes.c_void_p
 ssl.EC_KEY_new_by_curve_name.errcheck = check_result
 
 class KEY:
+    """ """
 
     def __init__(self):
+        """ """
         self.POINT_CONVERSION_COMPRESSED = 2
         self.POINT_CONVERSION_UNCOMPRESSED = 4
         self.k = ssl.EC_KEY_new_by_curve_name(NID_secp256k1)
 
     def __del__(self):
+        """ """
         if ssl:
             ssl.EC_KEY_free(self.k)
         self.k = None
 
     def generate(self, secret=None):
+        """ """
         if secret:
             self.prikey = secret
             priv_key = ssl.BN_bin2bn(secret, 32, ssl.BN_new())
@@ -50,26 +55,31 @@ class KEY:
             return ssl.EC_KEY_generate_key(self.k)
 
     def set_privkey(self, key):
+        """ """
         self.mb = ctypes.create_string_buffer(key)
         ssl.d2i_ECPrivateKey(ctypes.byref(self.k), ctypes.byref(ctypes.pointer(self.mb)), len(key))
 
     def set_pubkey(self, key):
+        """ """
         self.mb = ctypes.create_string_buffer(key)
         ssl.o2i_ECPublicKey(ctypes.byref(self.k), ctypes.byref(ctypes.pointer(self.mb)), len(key))
 
     def get_privkey(self):
+        """ """
         size = ssl.i2d_ECPrivateKey(self.k, 0)
         mb_pri = ctypes.create_string_buffer(size)
         ssl.i2d_ECPrivateKey(self.k, ctypes.byref(ctypes.pointer(mb_pri)))
         return mb_pri.raw
 
     def get_pubkey(self):
+        """ """
         size = ssl.i2o_ECPublicKey(self.k, 0)
         mb = ctypes.create_string_buffer(size)
         ssl.i2o_ECPublicKey(self.k, ctypes.byref(ctypes.pointer(mb)))
         return mb.raw
 
     def sign(self, hash):
+        """ """
         sig_size = ssl.ECDSA_size(self.k)
         mb_sig = ctypes.create_string_buffer(sig_size)
         sig_size0 = ctypes.c_uint32()
@@ -77,9 +87,11 @@ class KEY:
         return mb_sig.raw[:sig_size0.value]
 
     def verify(self, hash, sig):
+        """ """
         return ssl.ECDSA_verify(0, hash, len(hash), sig, len(sig), self.k)
 
     def set_compressed(self, compressed):
+        """ """
         if compressed:
             form = self.POINT_CONVERSION_COMPRESSED
         else:
@@ -87,6 +99,7 @@ class KEY:
         ssl.EC_KEY_set_conv_form(self.k, form)
 
     def get_secret(self):
+        """ """
         bn = ssl.EC_KEY_get0_private_key(self.k)
         mb = ctypes.create_string_buffer(32)
         ssl.BN_bn2bin(bn, mb)

--- a/honeybadgerbft/crypto/ecdsa/generate_keys_ecdsa.py
+++ b/honeybadgerbft/crypto/ecdsa/generate_keys_ecdsa.py
@@ -3,6 +3,7 @@ import argparse
 import cPickle
 
 def main():
+    """ """
     parser = argparse.ArgumentParser()
     parser.add_argument('players', help='The number of players');
     args = parser.parse_args()

--- a/honeybadgerbft/crypto/threshenc/__init__.py
+++ b/honeybadgerbft/crypto/threshenc/__init__.py
@@ -1,1 +1,3 @@
+"""Threshold Encryption modules"""
+
 __author__ = 'aluex'

--- a/honeybadgerbft/crypto/threshenc/generate_keys.py
+++ b/honeybadgerbft/crypto/threshenc/generate_keys.py
@@ -3,6 +3,7 @@ import argparse
 import cPickle
 
 def main():
+    """ """
     parser = argparse.ArgumentParser()
     parser.add_argument('players', help='The number of players')
     parser.add_argument('k', help='k')
@@ -19,4 +20,4 @@ def main():
 
 if __name__ == '__main__':
     main()
-    
+

--- a/honeybadgerbft/crypto/threshsig/__init__.py
+++ b/honeybadgerbft/crypto/threshsig/__init__.py
@@ -1,3 +1,3 @@
-__all__ = ["millerrabin", "boldyreva", "boldyreva_gpic", "generate_keys"]
+__all__ = ["millerrabin", "boldyreva", "boldyreva_gipc", "generate_keys"]
 import millerrabin
 import generate_keys

--- a/honeybadgerbft/crypto/threshsig/__init__.py
+++ b/honeybadgerbft/crypto/threshsig/__init__.py
@@ -1,3 +1,7 @@
-__all__ = ["millerrabin", "boldyreva", "boldyreva_gipc", "generate_keys"]
-import millerrabin
+import boldyreva
+import boldyreva_gipc
 import generate_keys
+import millerrabin
+
+
+__all__ = ["millerrabin", "boldyreva", "boldyreva_gipc", "generate_keys"]

--- a/honeybadgerbft/crypto/threshsig/boldyreva_gipc.py
+++ b/honeybadgerbft/crypto/threshsig/boldyreva_gipc.py
@@ -5,17 +5,18 @@ import time
 import random
 
 if '_procs' in globals():
-    for p,pipe in _procs: 
+    for p,pipe in _procs:
         p.terminate()
         p.join()
     del _procs
 _procs = []
 
 def _worker(PK,pipe):
+    """ """
     while True:
         (h, sigs) = pipe.get()
         sigs = dict(sigs)
-        for s in sigs: 
+        for s in sigs:
             sigs[s] = deserialize1(sigs[s])
         h = deserialize1(h)
         sig = PK.combine_shares(sigs)
@@ -25,6 +26,7 @@ def _worker(PK,pipe):
 myPK = None
 
 def initialize(PK, size=1):
+    """ """
     global _procs, myPK
     myPK = PK
     _procs = []
@@ -34,6 +36,7 @@ def initialize(PK, size=1):
         _procs.append((p,w))
 
 def combine_and_verify(h, sigs):
+    """ """
     # return True  # we are skipping the verification
     assert len(sigs) == myPK.k
     sigs = dict((s,serialize(v)) for s,v in sigs.iteritems())
@@ -41,11 +44,12 @@ def combine_and_verify(h, sigs):
     # Pick a random process
     _,pipe = _procs[random.choice(range(len(_procs)))] #random.choice(_procs)
     pipe.put((h,sigs))
-    (r,s) = pipe.get() 
+    (r,s) = pipe.get()
     assert r == True
     return s
 
 def pool_test():
+    """ """
     global PK, SKs
     PK, SKs = dealer(players=64,k=17)
 
@@ -62,7 +66,7 @@ def pool_test():
 
     # Combine 100 times
     if 1:
-        #promises = [pool.apply_async(_combine_and_verify, 
+        #promises = [pool.apply_async(_combine_and_verify,
         #                             (_h, sigs2))
         #            for i in range(100)]
         threads = []

--- a/honeybadgerbft/crypto/threshsig/boldyreva_pool.py
+++ b/honeybadgerbft/crypto/threshsig/boldyreva_pool.py
@@ -1,10 +1,11 @@
 from boldyreva import dealer, serialize, deserialize1, deserialize2
-import multiprocessing 
+import multiprocessing
 
 _pool_PK = None
 _pool = None
 
 def initialize(PK):
+    """ """
     from multiprocessing import Pool
     global _pool
     _pool = Pool()
@@ -14,9 +15,10 @@ def initialize(PK):
     _pool_PK = PK
 
 def _combine_and_verify(h, sigs):
+    """ """
     global _pool_PK
     sigs = dict(sigs)
-    for s in sigs: 
+    for s in sigs:
         sigs[s] = deserialize1(sigs[s])
     h = deserialize1(h)
     sig = PK.combine_shares(sigs)
@@ -24,6 +26,7 @@ def _combine_and_verify(h, sigs):
     return True
 
 def combine_and_verify(h, sigs):
+    """ """
     assert len(sigs) == _pool_PK.k
     sigs = dict((s,serialize(v)) for s,v in sigs.iteritems())
     h = serialize(h)
@@ -33,6 +36,7 @@ def combine_and_verify(h, sigs):
 
 
 def pool_test():
+    """ """
     global PK, SKs
     PK, SKs = dealer(players=64,k=17)
 
@@ -53,7 +57,7 @@ def pool_test():
 
     # Combine 100 times
     if 1:
-        promises = [pool.apply_async(_combine_and_verify, 
+        promises = [pool.apply_async(_combine_and_verify,
                                      (_h, sigs2))
                     for i in range(100)]
         print 'launched', time.time()

--- a/honeybadgerbft/crypto/threshsig/generate_keys.py
+++ b/honeybadgerbft/crypto/threshsig/generate_keys.py
@@ -3,6 +3,7 @@ import argparse
 import cPickle
 
 def main():
+    """ """
     parser = argparse.ArgumentParser()
     parser.add_argument('players', help='The number of players')
     parser.add_argument('k', help='k')
@@ -19,4 +20,4 @@ def main():
 
 if __name__ == '__main__':
     main()
-    
+

--- a/honeybadgerbft/crypto/threshsig/millerrabin.py
+++ b/honeybadgerbft/crypto/threshsig/millerrabin.py
@@ -19,10 +19,10 @@ _mrpt_num_trials = 50 # number of bases to test
 def is_probable_prime(n):
     """
     Miller-Rabin primality test.
- 
+
     A return value of False means n is certainly not prime. A return value of
     True means n is very likely a prime.
- 
+
     >>> is_probable_prime(1)
     Traceback (most recent call last):
         ...
@@ -37,19 +37,19 @@ def is_probable_prime(n):
     True
     >>> is_probable_prime(123456789)
     False
- 
+
     >>> primes_under_1000 = [i for i in range(2, 1000) if is_probable_prime(i)]
     >>> len(primes_under_1000)
     168
     >>> primes_under_1000[-10:]
     [937, 941, 947, 953, 967, 971, 977, 983, 991, 997]
- 
+
     >>> is_probable_prime(6438080068035544392301298549614926991513861075340134\
 3291807343952413826484237063006136971539473913409092293733259038472039\
 7133335969549256322620979036686633213903952966175107096769180017646161\
 851573147596390153)
     True
- 
+
     >>> is_probable_prime(7438080068035544392301298549614926991513861075340134\
 3291807343952413826484237063006136971539473913409092293733259038472039\
 7133335969549256322620979036686633213903952966175107096769180017646161\
@@ -83,10 +83,10 @@ def is_probable_prime(n):
             if pow(a, 2**i * d, n) == n-1:
                 return False
         return True # n is definitely composite
- 
+
     for i in range(_mrpt_num_trials):
         a = random.randrange(2, n)
         if try_composite(a):
             return False
- 
+
     return True # no base tested showed n as composite

--- a/honeybadgerbft/crypto/threshsig/millerrabin.py
+++ b/honeybadgerbft/crypto/threshsig/millerrabin.py
@@ -2,17 +2,17 @@ import random
 import math
 
 def generateLargePrime(k):
-     #k is the desired bit length
-     r=100*(math.log(k,2)+1) #number of attempts max
-     r_ = r
-     while r>0:
-        #randrange is mersenne twister and is completely deterministic
-        #unusable for serious crypto purposes
-         n = random.randrange(2**(k-1),2**(k))
-         r-=1
-         if is_probable_prime(n) == True:
-             return n
-     return "Failure after "+`r_` + " tries."
+    #k is the desired bit length
+    r=100*(math.log(k,2)+1) #number of attempts max
+    r_ = r
+    while r>0:
+       #randrange is mersenne twister and is completely deterministic
+       #unusable for serious crypto purposes
+        n = random.randrange(2**(k-1),2**(k))
+        r-=1
+        if is_probable_prime(n) == True:
+            return n
+    return "Failure after "+`r_` + " tries."
 
 _mrpt_num_trials = 50 # number of bases to test
 

--- a/test/test_honeybadger.py
+++ b/test/test_honeybadger.py
@@ -12,11 +12,12 @@ from collections import defaultdict
 
 def simple_router(N, maxdelay=0.005, seed=None):
     """Builds a set of connected channels, with random delay
-    @return (receives, sends)
+
+    :return: (receives, sends)
     """
     rnd = random.Random(seed)
     #if seed is not None: print 'ROUTER SEED: %f' % (seed,)
-    
+
     queues = [Queue() for _ in range(N)]
     _threads = []
 
@@ -34,7 +35,7 @@ def simple_router(N, maxdelay=0.005, seed=None):
             #print 'RECV %8s [%2d -> %2d]' % (o[0], i, j)
             return (i,o)
         return _recv
-        
+
     return ([makeSend(i) for i in range(N)],
             [makeRecv(j) for j in range(N)])
 
@@ -46,7 +47,7 @@ def _test_honeybadger(N=4, f=1, seed=None):
     sPK, sSKs = dealer(N, f+1, seed=seed)
     # Generate threshold enc keys
     ePK, eSKs = tpke.dealer(N, f+1)
-    
+
     rnd = random.Random(seed)
     #print 'SEED:', seed
     router_seed = rnd.random()
@@ -69,7 +70,7 @@ def _test_honeybadger(N=4, f=1, seed=None):
 
     for i in range(N):
         badgers[i].submit_tx('<[HBBFT Input %d]>' % (i+20))
-        
+
     #gevent.killall(threads[N-f:])
     #gevent.sleep(3)
     #for i in range(N-f, N):
@@ -79,7 +80,7 @@ def _test_honeybadger(N=4, f=1, seed=None):
 
         # Consistency check
         assert len(set(outs)) == 1
-        
+
     except KeyboardInterrupt:
         gevent.killall(threads)
         raise


### PR DESCRIPTION
### TODO before this can be merged
- [x] **Wait for #22 to be merged.**
- [x] use the standard rst style for docstrings as decided in #20
- [x] follow docstrings convention outlined in [PEP 257](https://www.python.org/dev/peps/pep-0257/) regarding double-quotes:
     > For consistency, always use """triple double quotes""" around docstrings.

---

This pull request proposes to add a documentation section entitled "Library Reference" that documents the code based on the existing docstrings found throughout the code.

Minor corrections have been done to the docstrings in order to build the documentation.

Examples of generated docs:

![image](https://user-images.githubusercontent.com/125458/29436806-c438ecba-83ad-11e7-92b7-bd8b723f67de.png)

![image](https://user-images.githubusercontent.com/125458/29436728-5253d2e0-83ad-11e7-98c9-fec48107a7ce.png)

Lastly, small edits (such as removing extra white space) are included as there were automatically applied as a result of the text editor used by the author of this pull request.