### PR TITLE
Set concurrency for coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,6 @@
 [run]
 source = .
 omit = *test*, docs/*, setup.py
+
+[run]
+concurrency = gevent


### PR DESCRIPTION
Prevents confusing code coverage errors.

> `Coverage.py` can measure multi-threaded programs by default. If you are using more exotic concurrency, with the `multiprocessing`, `greenlet`, `eventlet`, or `gevent` libraries, then `coverage.py` will get very confused. Use the `--concurrency` switch to properly measure programs using these libraries. Give it a value of `multiprocessing`, `thread`, `greenlet`, `eventlet`, or `gevent`. Values other than `thread` require the [C extension](https://coverage.readthedocs.io/en/latest/install.html#install-extension).

-- `coverage.py` docs: https://coverage.readthedocs.io/en/latest/cmd.html#execution

With this simple change, the overall coverage increases by **6.78%**. An interesting module is 
`honeybadgerbft/core/honeybadger_block.py`. Its coverage _almost_ doubles! It goes from [46.67%](https://codecov.io/gh/amiller/HoneyBadgerBFT/src/dev/honeybadgerbft/core/honeybadger_block.py) to   
[93.33%](https://codecov.io/gh/amiller/HoneyBadgerBFT/src/coverage-concurrency/honeybadgerbft/core/honeybadger_block.py) -- (increase of **46.66%**).

The commit e6263dad970da7a7a31171559ed2cf996cb03f67 of this PR was initially added as part of #27 and is now being extracted in this PR to simplify review, and also so that other PRs can benefit from it.