### PR TITLE
Use jessie instead of stretch for python image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.13-stretch
+FROM python:2.7.14
 
 # Default cluster arguments. Override with "-e"
 #


### PR DESCRIPTION
temporary fix for issue #43 