### PR TITLE
Allow the coverage to drop by 1%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,6 +5,10 @@ coverage:
   range: 70..100
   round: down
   precision: 5
+  status:
+    project:
+      default:
+        threshold: 1%
 
   ignore:
     - "docs/*"


### PR DESCRIPTION
At least for the time being, that should help dealing with PRs that somehow fail, because of `0.10 %` coverage decreases meanwhile no actual implementation code was modified.

Based on https://docs.codecov.io/docs/commit-status#section-threshold.